### PR TITLE
Fix wildcard matching in Azure sizing script

### DIFF
--- a/Azure Sizing/Azure_SQL_VM.ps1
+++ b/Azure Sizing/Azure_SQL_VM.ps1
@@ -33,11 +33,13 @@ function Test-Permission {
     )
     foreach ($entry in $PermissionEntries) {
         foreach ($allowed in $entry.actions) {
-            $regex = [regex]::Escape($allowed) -replace '\\\*', '.*'
+            # Replace escaped wildcard characters so that permissions with
+            # wildcards like "Microsoft.Sql/servers/*" are matched correctly.
+            $regex = [regex]::Escape($allowed) -replace '\\*', '.*'
             if ($RequiredPermission -match "^$regex$") {
                 $excluded = $false
                 foreach ($denied in $entry.notActions) {
-                    $nregex = [regex]::Escape($denied) -replace '\\\*', '.*'
+                    $nregex = [regex]::Escape($denied) -replace '\\*', '.*'
                     if ($RequiredPermission -match "^$nregex$") {
                         $excluded = $true
                         break
@@ -55,6 +57,7 @@ function Test-Permission {
 # Get all subscriptions
 $subscriptions = Get-AzSubscription
 $results = @()
+$detailedResults = @()
 
 foreach ($sub in $subscriptions) {
     Write-Output "Processing subscription: $($sub.Name) ($($sub.Id))"
@@ -92,11 +95,21 @@ foreach ($sub in $subscriptions) {
             if ($databases) {
                 foreach ($db in $databases) {
                     $sqlInstanceCount++
+                    $dbSizeTB = 0
                     if ($db.MaxSizeBytes) {
                         $parsedValue = 0
                         if ([long]::TryParse($db.MaxSizeBytes.ToString(), [ref]$parsedValue)) {
                             $totalSQLSizeBytes += $parsedValue
+                            $dbSizeTB = [math]::Round($parsedValue / $oneTBBytes, 2)
                         }
+                    }
+                    $detailedResults += [pscustomobject]@{
+                        SubscriptionName  = $sub.Name
+                        SubscriptionId    = $sub.Id
+                        ResourceGroupName = $server.ResourceGroupName
+                        ResourceType      = 'SQLDatabase'
+                        ResourceName      = $db.DatabaseName
+                        SizeTB            = $dbSizeTB
                     }
                 }
             }
@@ -123,6 +136,14 @@ foreach ($sub in $subscriptions) {
                 }
             }
             $totalDiskSizeGB += $vmDiskSizeGB
+            $detailedResults += [pscustomobject]@{
+                SubscriptionName  = $sub.Name
+                SubscriptionId    = $sub.Id
+                ResourceGroupName = $vm.ResourceGroupName
+                ResourceType      = 'VirtualMachine'
+                ResourceName      = $vm.Name
+                SizeGB            = $vmDiskSizeGB
+            }
         }
     }
     $totalDiskSizeTB = [math]::Round($totalDiskSizeGB / $oneTBGB, 2)
@@ -146,3 +167,8 @@ Write-Output "Total subscriptions processed: $($results.Count)"
 $csvPath = Join-Path -Path (Get-Location) -ChildPath "AzureResourceSizes.csv"
 $results | Export-Csv -Path $csvPath -NoTypeInformation -Force
 Write-Output "Results have been written to CSV file: $csvPath"
+
+# Write detailed object information to CSV for further analysis
+$detailsPath = Join-Path -Path (Get-Location) -ChildPath "AzureResourceDetails.csv"
+$detailedResults | Export-Csv -Path $detailsPath -NoTypeInformation -Force
+Write-Output "Detailed results have been written to CSV file: $detailsPath"


### PR DESCRIPTION
## Summary
- improve wildcard handling in `Test-Permission`
- add resource group info for each object to break out details in Excel

## Testing
- `pwsh --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b91c1dd3483329f1fb40eb94b6d58